### PR TITLE
Bugfix/foreign key mismatch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    descripto (0.2.0)
+    descripto (0.2.1)
       rails (~> 7.0)
 
 GEM
@@ -125,6 +125,8 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.6.0)

--- a/app/models/descripto/description.rb
+++ b/app/models/descripto/description.rb
@@ -12,7 +12,7 @@
 #
 module Descripto
   class Description < ActiveRecord::Base
-    has_many :descriptives, dependent: :destroy, foreign_key: :descripto_description_id
+    has_many :descriptives, dependent: :destroy
 
     validates :name, uniqueness: { scope: %i[category description_type] }
   end

--- a/app/models/descripto/descriptive.rb
+++ b/app/models/descripto/descriptive.rb
@@ -19,7 +19,7 @@
 #
 module Descripto
   class Descriptive < ActiveRecord::Base
-    belongs_to :description, class_name: "Descripto::Description", foreign_key: :descripto_description_id
+    belongs_to :description, class_name: "Descripto::Description"
     belongs_to :describable, polymorphic: true, touch: true
 
     validates :description, uniqueness: { scope: %i[describable_type describable_id] }

--- a/lib/descripto/version.rb
+++ b/lib/descripto/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Descripto
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/dummy/db/migrate/20250218063216_create_descripto_tables.rb
+++ b/test/dummy/db/migrate/20250218063216_create_descripto_tables.rb
@@ -10,7 +10,7 @@ class CreateDescriptoTables < ActiveRecord::Migration[7.0]
     end
 
     create_table :descripto_descriptives do |t|
-      t.references :descripto_description, null: false, foreign_key: true
+      t.references :description, null: false, foreign_key: { to_table: :descripto_descriptions }
       t.bigint :describable_id
       t.string :describable_type
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -21,12 +21,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_063638) do
   end
 
   create_table "descripto_descriptives", force: :cascade do |t|
-    t.integer "descripto_description_id", null: false
+    t.integer "description_id", null: false
     t.bigint "describable_id"
     t.string "describable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["descripto_description_id"], name: "index_descripto_descriptives_on_descripto_description_id"
+    t.index ["description_id"], name: "index_descripto_descriptives_on_description_id"
   end
 
   create_table "people", force: :cascade do |t|
@@ -35,5 +35,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_063638) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "descripto_descriptives", "descripto_descriptions"
+  add_foreign_key "descripto_descriptives", "descripto_descriptions", column: "description_id"
 end

--- a/test/dummy/test/models/person_test.rb
+++ b/test/dummy/test/models/person_test.rb
@@ -30,4 +30,39 @@ class PersonTest < ActiveSupport::TestCase
   def test_people_can_have_description
     assert @person.nationality.present?
   end
+
+  def test_description_can_be_added
+    interest = Descripto::Description.create(
+      name: "Tennis",
+      name_key: "tennis",
+      description_type: "interest"
+    )
+
+    @person.interests << interest
+    assert @person.reload.interests.include?(interest)
+  end
+
+  def test_descriptions_can_be_set_with_ids
+    interest = Descripto::Description.create(
+      name: "Music",
+      name_key: "music",
+      description_type: "interest"
+    )
+
+    @person.interest_ids = @person.interest_ids + [interest.id]
+    @person.save
+    assert @person.reload.interests.include?(interest)
+  end
+
+  def test_has_one_description_can_be_set_with_id
+    nationality = Descripto::Description.create(
+      name: "French",
+      name_key: "french",
+      description_type: "nationality"
+    )
+
+    @person.nationality_id = nationality.id
+    @person.save
+    assert @person.reload.nationality = nationality
+  end
 end


### PR DESCRIPTION
## Summary
There's a foreign key mismatch between the descriptives table and the descripto concern. The error happens when the concern tries to define the custom has_one id setter, and wants to set it with `description_id`, while the foreign key is `descripto_description_id`. 

## How will it work?
Instead of adjusting the concern, this PR adjusts the migration so that the foreign key is simply description_id. There's no need for this to be namespaced, and will make it easier to work with when we're working with the models.

## Intended outcome
Fix mismatch and improve foreign key naming
