### PR TITLE
Feat/support scoped descriptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    descripto (0.3.0)
+    descripto (0.4.0)
       rails (~> 7.0)
 
 GEM

--- a/lib/descripto/version.rb
+++ b/lib/descripto/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Descripto
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    descripto (0.2.0)
+    descripto (0.4.0)
       rails (~> 7.0)
 
 GEM

--- a/test/dummy/app/models/person.rb
+++ b/test/dummy/app/models/person.rb
@@ -3,5 +3,7 @@
 class Person < ApplicationRecord
   include Descripto::Associated
 
-  described_by :nationality, :interests, limits: { interests: { maximum: 5 } }
+  described_by :nationality, :interests,
+               interests: { limits: { maximum: 5 } },
+               nationality: { scoped: true }
 end

--- a/test/dummy/test/fixtures/descripto/descriptions.yml
+++ b/test/dummy/test/fixtures/descripto/descriptions.yml
@@ -9,4 +9,4 @@ programming:
 norwegian:
   name: 'Norwegian'
   name_key: 'norwegian'
-  description_type: 'nationality'
+  description_type: 'person_nationality'

--- a/test/dummy/test/models/person_test.rb
+++ b/test/dummy/test/models/person_test.rb
@@ -65,4 +65,18 @@ class PersonTest < ActiveSupport::TestCase
     @person.save
     assert @person.reload.nationality = nationality
   end
+
+  def test_should_scope_description_type_if_scoped
+    interest_options = Person.descripto_descriptions[:options][:interests]
+    assert interest_options[:scoped].blank?
+
+    interests_description_type = Person.first.interests.first.description_type
+    assert interests_description_type.exclude?("person")
+
+    nationality_options = Person.descripto_descriptions[:options][:nationality]
+    assert nationality_options[:scoped].eql?(true)
+
+    nationality_description_type = Person.first.nationality.description_type
+    assert nationality_description_type.include?("person")
+  end
 end


### PR DESCRIPTION
## Summary
We need to support scoping descriptions in case we have multiple models that share the same description type name, but where they're not supposed to share the same records.

## How will it work?
- Add prefix `"#{model_name}_"` if option `scoped: true` is given
- Not necessary to prefix the association name itself
- Add test

## Intended outcome
Adds support for scoping descriptions
