### PR TITLE
chore(ENG-2661): Dynamic model parent class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
 PLATFORMS
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/descripto/description.rb
+++ b/app/models/descripto/description.rb
@@ -11,7 +11,7 @@
 #  updated_at       :datetime         not null
 #
 module Descripto
-  class Description < ActiveRecord::Base
+  class Description < parent_model_class.constantize
     has_many :descriptives, dependent: :destroy
 
     validates :name, uniqueness: { scope: %i[category description_type] }

--- a/app/models/descripto/descriptive.rb
+++ b/app/models/descripto/descriptive.rb
@@ -18,7 +18,7 @@
 #  fk_rails_...  (description_id => descriptions.id)
 #
 module Descripto
-  class Descriptive < ActiveRecord::Base
+  class Descriptive < parent_model_class.constantize
     belongs_to :description, class_name: "Descripto::Description"
     belongs_to :describable, polymorphic: true, touch: true
 

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+$: << File.expand_path("../test", __dir__)
+
+require "bundler/setup"
+require "rails/plugin/test"

--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-$: << File.expand_path("../test", __dir__)
-
-require "bundler/setup"
-require "rails/plugin/test"

--- a/lib/descripto.rb
+++ b/lib/descripto.rb
@@ -7,6 +7,8 @@ require "action_controller/railtie"
 require "rails/engine"
 
 module Descripto
+  mattr_accessor :parent_model_class, default: "ApplicationRecord"
+
   class Error < StandardError; end
 
   class Engine < Rails::Engine

--- a/test/descripto_test.rb
+++ b/test/descripto_test.rb
@@ -3,7 +3,16 @@
 require "test_helper"
 
 class TestDescripto < ActiveSupport::TestCase
-  def test_it_has_a_version_number
-    refute_nil ::Descripto::VERSION
+  test "should have version number" do
+    refute_nil Descripto::VERSION
+  end
+
+  test "should have parent model class" do
+    refute_nil Descripto.parent_model_class
+  end
+
+  test "should be able to set parent model class" do
+    Descripto.parent_model_class = "ActiveRecord::Base"
+    assert_equal "ActiveRecord::Base", Descripto.parent_model_class
   end
 end

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -192,6 +192,7 @@ GEM
 PLATFORMS
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-24
 
 DEPENDENCIES
   byebug


### PR DESCRIPTION
## Summary
Added default parent model class configuration to allow customization of model inheritance. Models now inherit from a configurable parent class (defaulting to ApplicationRecord) instead of directly from ActiveRecord::Base. Includes test coverage and updated dependencies.

## How will it work?
- [x] Add default parent model class as configuration

## Intended outcome
Ability to add custom base model functionality across all Descripto models