### PR TITLE
fix(ENG-2753): has_one not being set

### DIFF
--- a/lib/descripto/customized.rb
+++ b/lib/descripto/customized.rb
@@ -36,7 +36,7 @@ module Descripto
 
           descriptives.where(description: current_description).destroy_all if current_description
 
-          descriptives.build(description: description) if description.present?
+          descriptions << description if description.present?
 
           # Reset getter cache so it sees the new state
           # Don't reset descriptives association as it would clear the built object

--- a/test/dummy/app/models/contact.rb
+++ b/test/dummy/app/models/contact.rb
@@ -1,0 +1,7 @@
+class Contact < ApplicationRecord
+  include Descripto::Associated
+
+  belongs_to :contactable, polymorphic: true
+
+  described_by :job_position
+end

--- a/test/dummy/app/models/organization.rb
+++ b/test/dummy/app/models/organization.rb
@@ -1,0 +1,5 @@
+class Organization < ApplicationRecord
+  has_many :persons, dependent: :destroy
+
+  accepts_nested_attributes_for :persons
+end

--- a/test/dummy/app/models/person.rb
+++ b/test/dummy/app/models/person.rb
@@ -3,6 +3,8 @@
 class Person < ApplicationRecord
   include Descripto::Associated
 
+  belongs_to :organization
+
   described_by :nationality, :interests,
                options: {
                  interests: { limits: { maximum: 5 } },
@@ -10,6 +12,10 @@ class Person < ApplicationRecord
                }
 
   validate :nationality_must_be_scoped
+
+  has_one :contact, as: :contactable
+
+  accepts_nested_attributes_for :contact, update_only: true
 
   def nationality_must_be_scoped
     return if nationality.description_type == "person_nationality"

--- a/test/dummy/db/migrate/20250718063734_create_organizations.rb
+++ b/test/dummy/db/migrate/20250718063734_create_organizations.rb
@@ -1,0 +1,8 @@
+class CreateOrganizations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :organizations do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20250718064212_add_organization_to_persons.rb
+++ b/test/dummy/db/migrate/20250718064212_add_organization_to_persons.rb
@@ -1,0 +1,5 @@
+class AddOrganizationToPersons < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :people, :organization, null: false, foreign_key: true
+  end
+end

--- a/test/dummy/db/migrate/20250718065649_create_contacts.rb
+++ b/test/dummy/db/migrate/20250718065649_create_contacts.rb
@@ -1,0 +1,9 @@
+class CreateContacts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :contacts do |t|
+      t.string :email
+      t.references :contactable, polymorphic: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_19_063638) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_18_065649) do
+  create_table "contacts", force: :cascade do |t|
+    t.string "email"
+    t.string "contactable_type", null: false
+    t.integer "contactable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contactable_type", "contactable_id"], name: "index_contacts_on_contactable"
+  end
+
   create_table "descripto_descriptions", force: :cascade do |t|
     t.string "name"
     t.string "name_key"
@@ -29,11 +38,20 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_063638) do
     t.index ["description_id"], name: "index_descripto_descriptives_on_description_id"
   end
 
-  create_table "people", force: :cascade do |t|
+  create_table "organizations", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
+  create_table "people", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "organization_id", null: false
+    t.index ["organization_id"], name: "index_people_on_organization_id"
+  end
+
   add_foreign_key "descripto_descriptives", "descripto_descriptions", column: "description_id"
+  add_foreign_key "people", "organizations"
 end

--- a/test/dummy/test/fixtures/contacts.yml
+++ b/test/dummy/test/fixtures/contacts.yml
@@ -1,0 +1,3 @@
+jan_tore:
+  email: jan@midstay.com
+  contactable: jan_tore (Person)

--- a/test/dummy/test/fixtures/descripto/descriptions.yml
+++ b/test/dummy/test/fixtures/descripto/descriptions.yml
@@ -10,3 +10,15 @@ norwegian:
   name: 'Norwegian'
   name_key: 'norwegian'
   description_type: 'person_nationality'
+indonesian:
+  name: 'Indonesian'
+  name_key: 'indonesian'
+  description_type: 'person_nationality'
+ceo:
+  name: 'CEO'
+  name_key: 'ceo'
+  description_type: 'job_position'
+cto:
+  name: 'CTO'
+  name_key: 'cto'
+  description_type: 'job_position'

--- a/test/dummy/test/fixtures/descripto/descriptives.yml
+++ b/test/dummy/test/fixtures/descripto/descriptives.yml
@@ -4,3 +4,6 @@ jan_tore_football:
 jan_tore_norwegian:
   description: norwegian
   describable: jan_tore (Person)
+jan_tore_ceo:
+  description: ceo
+  describable: jan_tore (Contact)

--- a/test/dummy/test/fixtures/organizations.yml
+++ b/test/dummy/test/fixtures/organizations.yml
@@ -1,0 +1,2 @@
+midstay:
+  name: Midstay

--- a/test/dummy/test/fixtures/people.yml
+++ b/test/dummy/test/fixtures/people.yml
@@ -1,2 +1,0 @@
-jan_tore:
- name: "Jan Tore"

--- a/test/dummy/test/fixtures/persons.yml
+++ b/test/dummy/test/fixtures/persons.yml
@@ -1,0 +1,3 @@
+jan_tore:
+  name: "Jan Tore"
+  organization: midstay

--- a/test/dummy/test/models/organization_test.rb
+++ b/test/dummy/test/models/organization_test.rb
@@ -1,0 +1,33 @@
+require_relative "../test_helper"
+
+class OrganizationTest < ActiveSupport::TestCase
+  test "create organization with persons" do
+    assert_difference "Organization.count" do
+      assert_difference "Person.count" do
+        assert_difference "Descripto::Descriptive.count" do
+          Organization.create(
+            name: "Midstay",
+            persons_attributes: [
+              { name: "Jan Tore", nationality_id: Person.nationalities.first.id }
+            ]
+          )
+        end
+      end
+    end
+  end
+
+  test "update organization with persons" do
+    organization = organizations(:midstay)
+    first_person = organization.persons.first
+
+    organization.update(persons_attributes: [
+                          {
+                            id: first_person.id,
+                            name: "#{first_person.name} updated",
+                            nationality_id: descripto_descriptions(:indonesian).id
+                          }
+                        ])
+
+    assert_equal descripto_descriptions(:indonesian), first_person.nationality
+  end
+end

--- a/test/dummy/test/models/person_test.rb
+++ b/test/dummy/test/models/person_test.rb
@@ -2,7 +2,7 @@ require_relative "../test_helper"
 
 class PersonTest < ActiveSupport::TestCase
   setup do
-    @person = people(:jan_tore)
+    @person = persons(:jan_tore)
   end
 
   def test_adds_description_with_concern_inclusion
@@ -71,40 +71,67 @@ class PersonTest < ActiveSupport::TestCase
     nationality_desc = descripto_descriptions(:norwegian)
 
     # Scenario 1: Person.new(nationality_id: id).save should work
-    person1 = Person.new(name: "Test Person 1", nationality_id: nationality_desc.id)
+    person1 = Person.new(
+      name: "Test Person 1",
+      nationality_id: nationality_desc.id,
+      organization: organizations(:midstay)
+    )
     assert_equal nationality_desc, person1.nationality, "Person.new(nationality_id: id) should work"
     assert_equal nationality_desc.id, person1.nationality_id, "nationality_id should be set correctly"
     assert person1.save, "Person should save successfully"
 
     # Scenario 2: Setting nationality= should work
-    person2 = Person.new(name: "Test Person 2")
+    person2 = Person.new(
+      name: "Test Person 2",
+      organization: organizations(:midstay)
+    )
     person2.nationality = nationality_desc
     assert_equal nationality_desc, person2.nationality, "Setting nationality= should work"
     assert_equal nationality_desc.id, person2.nationality_id, "nationality_id should be set correctly"
     assert person2.save, "Person should save successfully"
 
     # Scenario 3: Setting nationality_id= should work
-    person3 = Person.new(name: "Test Person 3")
+    person3 = Person.new(
+      name: "Test Person 3",
+      organization: organizations(:midstay)
+    )
     person3.nationality_id = nationality_desc.id
     assert_equal nationality_desc, person3.nationality, "Setting nationality_id= should work"
     assert_equal nationality_desc.id, person3.nationality_id, "nationality_id should be set correctly"
     assert person3.save, "Person should save successfully"
 
     # Scenario 4: Validations should work without crashing
-    person4 = Person.new(name: "Test Person 4", nationality_id: nationality_desc.id)
+    person4 = Person.new(
+      name: "Test Person 4",
+      nationality_id: nationality_desc.id,
+      organization: organizations(:midstay)
+    )
     assert person4.valid?, "Person should be valid"
   end
 
-  test "should be able to create contact" do
+  test "should be able to create person" do
     assert_difference "Person.count" do
       nationality = descripto_descriptions(:norwegian)
 
-      contact = Person.new(
+      person = Person.new(
         name: "John Doe",
+        organization: organizations(:midstay),
         nationality:
       )
 
-      contact.save
+      person.save
     end
+  end
+
+  test "update person with contact" do
+    person = persons(:jan_tore)
+    contact = person.contact
+    job_position = descripto_descriptions(:cto)
+
+    person.update(contact_attributes: {
+                    job_position_id: job_position.id
+                  })
+
+    assert_equal job_position, contact.job_position
   end
 end


### PR DESCRIPTION
## Summary
This PR addresses an issue where the `has_one` association was not being set correctly in the application. The fix ensures that the association is properly established and maintained.

## How will it work?
The implementation involves updating the relevant model logic to correctly assign and persist the `has_one` association. This may include changes to callbacks, assignment methods, or association options to guarantee that the related object is set as expected whenever the parent object is created or updated.

## Intended outcome
- The `has_one` association is reliably set and accessible on the parent model.
- No regressions or unintended side effects in related model behaviors.
- All relevant tests pass, confirming the association is established and maintained as intended.