### PR TITLE
fix: bug for namespaced model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    descripto (0.8.0)
+    descripto (0.8.1)
       rails (>= 7.0, < 9.0)
 
 GEM

--- a/lib/descripto/associated.rb
+++ b/lib/descripto/associated.rb
@@ -30,7 +30,7 @@ module Descripto
 
         return type.to_s.singularize unless options&.dig(:scoped)
 
-        "#{name.parameterize.underscore}_#{type.to_s.singularize}"
+        "#{model_name.singular}_#{type.to_s.singularize}"
       end
     end
   end

--- a/lib/descripto/version.rb
+++ b/lib/descripto/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Descripto
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    descripto (0.8.0)
+    descripto (0.8.1)
       rails (>= 7.0, < 9.0)
 
 GEM
@@ -124,6 +124,8 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux-gnu)
+      racc (~> 1.4)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -178,6 +180,7 @@ GEM
       io-console (~> 0.5)
     securerandom (0.4.1)
     sqlite3 (2.7.2-x86_64-darwin)
+    sqlite3 (2.7.2-x86_64-linux-gnu)
     stringio (3.1.7)
     thor (1.3.2)
     timeout (0.4.3)
@@ -195,6 +198,7 @@ PLATFORMS
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-24
+  x86_64-linux
 
 DEPENDENCIES
   byebug

--- a/test/dummy/app/models/venues/event_space.rb
+++ b/test/dummy/app/models/venues/event_space.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Venues
+  class EventSpace < ApplicationRecord
+    include Descripto::Associated
+
+    described_by :setups, options: { setups: { scoped: true } }
+  end
+end

--- a/test/dummy/db/migrate/20251021043449_create_venues_event_space.rb
+++ b/test/dummy/db/migrate/20251021043449_create_venues_event_space.rb
@@ -1,0 +1,8 @@
+class CreateVenuesEventSpace < ActiveRecord::Migration[8.0]
+  def change
+    create_table :venues_event_spaces do |t|
+      t.name
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_18_065649) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_21_043449) do
   create_table "contacts", force: :cascade do |t|
     t.string "email"
     t.string "contactable_type", null: false
@@ -50,6 +50,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_065649) do
     t.datetime "updated_at", null: false
     t.integer "organization_id", null: false
     t.index ["organization_id"], name: "index_people_on_organization_id"
+  end
+
+  create_table "venues_event_spaces", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "descripto_descriptives", "descripto_descriptions", column: "description_id"

--- a/test/dummy/test/models/venues/event_space_test.rb
+++ b/test/dummy/test/models/venues/event_space_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+module Venues
+  class EventSpaceTest < ActiveSupport::TestCase
+    test "should scoped the model correctly" do
+      assert_equal Venues::EventSpace.description_type_for(:setups), "venues_event_space_setup"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Previously for namespaced model that had a underscore, in our case `Venues::EventSpace` the generated `scoped_type` was producing `venues_eventspace_setup` without underscore between `event` and `space` and i believe we don't want that. we expecting the scoped_type to be `venues_event_space_setup`

<img width="589" height="128" alt="image" src="https://github.com/user-attachments/assets/2383818f-7bac-4355-b3c8-762ca691eece" />


- Bumped descripto version to 0.8.1 in Gemfile.lock and version.rb.
- Refactored associated method in Descripto module for namespaced model.
- Introduced EventSpace model under Venues with scoped description support.
- Created migration for venues_event_spaces table and updated schema.
- Added tests for EventSpace model to ensure correct namepsaced type handling.

## How will it work?
_Description of how it was implemented._

## Intended outcome
_Description of evaluation criterias to determine if the goal has been met._
